### PR TITLE
Create Issue templates using GitHub Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -2,50 +2,39 @@ name: "🐛 Bug Report"
 description: "Submit a bug report to help us improve"
 title: "🐛 Bug Report: "
 labels: [bug]
-
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time to fill out our bug report form 🙏
-
-        Use this template to submit a bug report to help us improve.
-
-        To make it easier for us to help you please enter detailed information below.
-
   - type: textarea
     id: steps-to-reproduce
     validations:
       required: true
     attributes:
-      label: "👟 Steps to Reproduce"
+      label: "👟 Reproduction steps"
       description: "How do you trigger this bug? Please walk us through it step by step."
-      placeholder: "1. When I ..."
-
+      placeholder: "When I ..."
   - type: textarea
     id: expected-behavior
     validations:
       required: true
     attributes:
-      label: "👍 Expected Behavior"
-      description: "Tell us what did you think would happen?"
+      label: "👍 Expected behavior"
+      description: "What did you think would happen?"
       placeholder: "It should ..."
-
   - type: textarea
     id: actual-behavior
     validations:
       required: true
     attributes:
       label: "👎 Actual Behavior"
-      description: "Tell us what should actually happen? Add screenshots, if applicable."
+      description: "What did actually happen? Add screenshots, if applicable."
       placeholder: "It actually ..."
-
   - type: dropdown
     id: appwrite-version
-    validations:
-      required: true
     attributes:
-      label: "🎲 Appwrite Version"
+      label: "🎲 Appwrite version"
       description: "What version of Appwrite are you running?"
       options:
         - Version 0.10.x
@@ -53,52 +42,41 @@ body:
         - Version 0.8.x
         - Version 0.7.x
         - Version 0.6.x
-        - Other (specify in environment)
-
-  - type: dropdown
-    id: operating-system
+        - Different version (specify in environment)
     validations:
       required: true
+  - type: dropdown
+    id: operating-system
     attributes:
-      label: "💻 Operating System"
+      label: "💻 Operating system"
       description: "What OS is your server / device running on?"
       options:
         - Linux
         - MacOS
         - Windows
-        - Other
-
+        - Something else
+    validations:
+      required: true
   - type: textarea
-    id: environment
+    id: enviromnemt
     validations:
       required: false
     attributes:
       label: "🧱 Your Environment"
       description: "Is your environment customized in any way?"
       placeholder: "I use Cloudflare for ..."
-
-  - type: textarea
-    id: additional-context
-    validations:
-      required: false
-    attributes:
-      label: "📝 Additional Context"
-      description: "You may provide any other additional context to the bug here."
-
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "👀 Have you checked if this issue has been raised before?"
+      label: "👀 Have you spent some time to check if this issue has been raised before?"
       description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
       options:
         - label: "I checked and didn't find similar issue"
           required: true
-
   - type: checkboxes
     id: read-code-of-conduct
     attributes:
-      description: "This is our [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md)."
       label: "🏢 Have you read the Code of Conduct?"
       options:
-        - label: "I read the Code of Conduct"
+        - label: "I have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/HEAD/CODE_OF_CONDUCT.md)"
           required: true

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for taking the time to fill out our bug report form 🙏
 
-        Use this template to notfy us if you found a bug.
+        Use this template to submit a bug report to help us improve.
 
         To make it easier for us to help you please enter detailed information below.
 

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,104 @@
+name: "🐛 Bug Report"
+description: "Submit a bug report to help us improve"
+title: "🐛 Bug Report: "
+labels: [bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our bug report form 🙏
+
+        Use this template to notfy us if you found a bug.
+
+        To make it easier for us to help you please enter detailed information below.
+
+  - type: textarea
+    id: steps-to-reproduce
+    validations:
+      required: true
+    attributes:
+      label: "👟 Steps to Reproduce"
+      description: "How do you trigger this bug? Please walk us through it step by step."
+      placeholder: "1. When I ..."
+
+  - type: textarea
+    id: expected-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👍 Expected Behavior"
+      description: "Tell us what did you think would happen?"
+      placeholder: "It should ..."
+
+  - type: textarea
+    id: actual-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👎 Actual Behavior"
+      description: "Tell us what should actually happen? Add screenshots, if applicable."
+      placeholder: "It actually ..."
+
+  - type: dropdown
+    id: appwrite-version
+    validations:
+      required: true
+    attributes:
+      label: "🎲 Appwrite Version"
+      description: "What version of Appwrite are you running?"
+      options:
+        - Version 0.10.x
+        - Version 0.9.x
+        - Version 0.8.x
+        - Version 0.7.x
+        - Version 0.6.x
+        - Other (specify in environment)
+
+  - type: dropdown
+    id: operating-system
+    validations:
+      required: true
+    attributes:
+      label: "💻 Operating System"
+      description: "What OS is your server / device running on?"
+      options:
+        - Linux
+        - MacOS
+        - Windows
+        - Other
+
+  - type: textarea
+    id: environment
+    validations:
+      required: false
+    attributes:
+      label: "🧱 Your Environment"
+      description: "Is your environment customized in any way?"
+      placeholder: "I use Cloudflare for ..."
+
+  - type: textarea
+    id: additional-context
+    validations:
+      required: false
+    attributes:
+      label: "📝 Additional Context"
+      description: "You may provide any other additional context to the bug here."
+
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you checked if this issue has been raised before?"
+      description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      description: "This is our [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md)."
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I read the Code of Conduct"
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -2,40 +2,31 @@ name: "📚 Documentation"
 description: "Report an issue related to documentation"
 title: "📚 Documentation: "
 labels: [documentation]
-
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out our bug report form 🙏
-
-        Use this template to report an issue related to documentation.
-
-        To make it easier for us to help you please enter detailed information below.
-
+        Thanks for taking the time to make our documentation better 🙏
   - type: textarea
     id: issue-description
     validations:
       required: true
     attributes:
       label: "💭 Description"
-      description: "Give us a clear and concise description of what the issue is."
+      description: "A clear and concise description of what the issue is."
       placeholder: "Documentation should not ..."
-
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
-      label: "👀 Have you checked if this issue has been raised before?"
+      label: "👀 Have you spent some time to check if this issue has been raised before?"
       description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
       options:
         - label: "I checked and didn't find similar issue"
           required: true
-
   - type: checkboxes
-    id: code-of-conduct
+    id: read-code-of-conduct
     attributes:
-      description: "This is our [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md)."
       label: "🏢 Have you read the Code of Conduct?"
       options:
-        - label: "I've read the Code of Conduct"
+        - label: "I have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/HEAD/CODE_OF_CONDUCT.md)"
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,41 @@
+name: "📚 Documentation"
+description: "Report an issue related to documentation"
+title: "📚 Documentation: "
+labels: [documentation]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our bug report form 🙏
+
+        Use this template to notfy us if you found a bug.
+
+        To make it easier for us to help you please enter detailed information below.
+
+  - type: textarea
+    id: issue-description
+    validations:
+      required: true
+    attributes:
+      label: "💭 Description"
+      description: "Give us a clear and concise description of what the issue is."
+      placeholder: "Documentation should not ..."
+
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you checked if this issue has been raised before?"
+      description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+
+  - type: checkboxes
+    id: code-of-conduct
+    attributes:
+      description: "This is our [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md)."
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I've read the Code of Conduct"
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for taking the time to fill out our bug report form 🙏
 
-        Use this template to notfy us if you found a bug.
+        Use this template to report an issue related to documentation.
 
         To make it easier for us to help you please enter detailed information below.
 

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -2,17 +2,11 @@ name: 🚀 Feature
 description: "Submit a proposal for a new feature"
 title: "🚀 Feature: "
 labels: [feature]
-
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out our bug report form 🙏
-
-        Use this template to submit a proposal for a new feature.
-
-        To make it easier for us to help you please enter detailed information below.
-
+        Thanks for taking the time to fill out our feature request form 🙏
   - type: textarea
     id: feature-description
     validations:
@@ -21,7 +15,6 @@ body:
       label: "🔖 Feature description"
       description: "A clear and concise description of what the feature is."
       placeholder: "You should add ..."
-
   - type: textarea
     id: pitch
     validations:
@@ -30,7 +23,6 @@ body:
       label: "🎤 Pitch"
       description: "Please explain why this feature should be implemented and how it would be used. Add examples, if applicable."
       placeholder: "In my use-case, ..."
-
   - type: checkboxes
     id: no-duplicate-issues
     attributes:
@@ -38,4 +30,11 @@ body:
       description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
       options:
         - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/appwrite/appwrite/blob/HEAD/CODE_OF_CONDUCT.md)"
           required: true

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,41 @@
+name: 🚀 Feature
+description: "Submit a proposal for a new feature"
+title: "🚀 Feature: "
+labels: [feature]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out our bug report form 🙏
+
+        Use this template to notfy us if you found a bug.
+
+        To make it easier for us to help you please enter detailed information below.
+
+  - type: textarea
+    id: feature-description
+    validations:
+      required: true
+    attributes:
+      label: "🔖 Feature description"
+      description: "A clear and concise description of what the feature is."
+      placeholder: "You should add ..."
+
+  - type: textarea
+    id: pitch
+    validations:
+      required: true
+    attributes:
+      label: "🎤 Pitch"
+      description: "Please explain why this feature should be implemented and how it would be used. Add examples, if applicable."
+      placeholder: "In my use-case, ..."
+
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this issue has been raised before?"
+      description: "Have you Googled for a similar issue or checked our older issues for a similar bug?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for taking the time to fill out our bug report form 🙏
 
-        Use this template to notfy us if you found a bug.
+        Use this template to submit a proposal for a new feature.
 
         To make it easier for us to help you please enter detailed information below.
 


### PR DESCRIPTION
This PR creates Issue templates using the GitHub Issue Forms.

**Fixes** #9 